### PR TITLE
Refactor API and zone update handling

### DIFF
--- a/_modules/powerdns.py
+++ b/_modules/powerdns.py
@@ -218,7 +218,7 @@ def post_zone(zone, payload, session=None):
 
   return _handle_result(result, 201)
 
-def patch_zone(zone, payload, changetype, session=None):
+def patch_zone(zone, payload, session=None):
   if session is None:
     session = _init()
 
@@ -260,7 +260,7 @@ def patch_rrsets(zone, changetype, session, recname=None, rectype=None, record=N
       }
     )
 
-  return patch_zone(zone, payload, changetype, session)
+  return patch_zone(zone, payload, session)
 
 def create_record(zone, recname, recttl, rectype, record, session=None):
   return patch_rrsets(zone, recname=recname, rectype=rectype, changetype='REPLACE', session=session, record=record, recttl=recttl)

--- a/_states/powerdns.py
+++ b/_states/powerdns.py
@@ -1,77 +1,277 @@
-# -*- coding: utf-8 -*-
-'''
-'''
-
-# Define the module's virtual name
 __virtualname__ = 'powerdns'
-
 
 def __virtual__():
     if 'powerdns.get_zone' in __salt__:
         return __virtualname__
     return False
 
-def test(name, *args, **kwargs):
-    zzz = __salt__['powerdns.argtest'](args, **kwargs)
-    ret = {'name': name,
-           'changes': {},
-           'result': zzz,
-           'comment': ''}
+import logging
+log = logging.getLogger(__name__)
 
-    return ret
+def zone_present(name, kind=None, rrsets=None, masters=None, dnssec=None, nsec3param=None, nsec3narrow=None, presigned=None, soa_edit=None, soa_edit_api=None, api_rectify=None, catalog=None, nameservers=None, master_tsig_key_ids=None, slave_tsig_key_ids=None):
 
-def zone_present(name, name_servers=None, records=None):
-    ret = {'name': name,
-           'changes': {},
-           'result': False,
-           'comment': ''}
+  want_data = {
+    key: value
+    for key, value in locals().items()
+    if value is not None
+  }
 
-    if __salt__['powerdns.zone_exists'](name):
-        ret['result'] = True
-        ret['comment'] = 'Zone already present.'
+  zone = __salt__['powerdns.canonicalize_name'](name)
+  want_data['name'] = zone
+
+  if 'kind' in want_data:
+    want_data['kind'] = want_data['kind'].capitalize()
+
+  ret = {'name': zone, 'changes': {}, 'result': False, 'comment': ''}
+
+  session = __salt__['powerdns.new_session'](True)
+  log.debug('powerdns: got session')
+  
+  exists = __salt__['powerdns.get_zone_exists'](zone, session)
+
+  log.debug(f'powerdns: zone exists => {exists}')
+  log.debug(f'powerdns: want data => {want_data}')
+
+  if exists:
+    if 'nameservers' in want_data:
+      del want_data['nameservers']
+
+    have_data = {
+      key: value
+      for key, value in __salt__['powerdns.get_zone'](zone, session).items()
+      if key in want_data
+    }
+
+    log.debug(f'powerdns: have data => {have_data}')
+
+    payload = {}
+    for key, want_value in want_data.items():
+      log.debug(f'powerdns: reading wanted key "{key}"')
+      have_value = have_data[key]
+      if want_value != have_value:
+        log.debug('powerdns: key differs')
+        ret['changes'][key] = {
+          'old': have_value,
+          'new': want_value,
+        }
+
+        payload.update(
+          {
+            key: want_value,
+          }
+        )
+
+    if not ret['changes']:
+      ret['result'] = True
+      ret['comment'] = 'Zone is already in the correct state.'
+      return ret
+
+    if ret['changes']:
+      if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Zone would be modified.'
         return ret
 
-    zone = __salt__['powerdns.add_zone'](name, name_servers, records)
-    if type(zone) is list:
-        ret['result'] = True
-        ret['comment'] = 'Zone present.'
-        ret['changes'] = { name : { 'old': '', 'new': zone } }
-        
-    return ret
+    if not 'rrsets' in payload:
+      payload['rrsets'] = []
 
-def zone_absent(name):
-    ret = {'name': name,
-           'changes': {},
-           'result': False,
-           'comment': ''}
+    ok, status, output = __salt__['powerdns.patch_zone'](zone, payload, 'REPLACE', session)
 
-    if not __salt__['powerdns.zone_exists'](name):
-        ret['result'] = True
-        ret['comment'] = 'Zone already absent.'
-        return ret
+    if ok:
+      ret['result'] = True
+      ret['comment'] = 'Zone modified: {status} - {output}'
+
     else:
-        zone = __salt__['powerdns.get_zone'](name)
+      ret['result'] = False
+      ret['comment'] = f'Zone modification failed: {status} - {output}'
 
-    if __salt__['powerdns.del_zone'](name):
-        ret['result'] = True
-        ret['comment'] = 'Zone absent.'
-        ret['changes'] = { name : { 'old': zone, 'new': '' } }
-        
     return ret
 
-def record_present(zone, name, record_type, ttl=300, records=[]):
-    ret = {'name': name,
-           'changes': {},
-           'result': False,
-           'comment': ''}
-    old_record = __salt__['powerdns.get_record'](zone, name, record_type)
-    if __salt__['powerdns.add_record'](zone, name, record_type, ttl, records=records):
-        ret['result'] = True
-        ret['comment'] = "Record present"
-        new_record = __salt__['powerdns.get_record'](zone, name, record_type)
-        if new_record == old_record:
-            ret['changes'] = {}
-        else:    
-            ret['changes'] = { name : { 'new': { 'zone': zone, 'name': name, 'type': record_type, 'ttl': ttl, 'records': records }, 'old': old_record } }
-    
+  else:  # zone does not exist
+    ret['changes'] = {
+      'new': want_data,
+      'old': {},
+    }
+
+    if __opts__['test']:
+      ret['result'] = None
+      ret['comment'] = 'Zone would be created.'
+      return ret
+
+    payload = want_data
+    ok, status, output = __salt__['powerdns.post_zone'](zone, payload, session)
+
+    if ok:
+      ret['result'] = True
+      ret['comment'] = f'Zone created: {status} - {output}'
+
+    else:
+      ret['result'] = False
+      ret['comment'] = f'Zone creation failed: {status} - {output}'
+
     return ret
+
+def rrsets_present(name, rrsets):
+  zone = __salt__['powerdns.canonicalize_name'](name)
+  ret = {'name': zone, 'changes': {}, 'result': False, 'comment': ''}
+
+  session = __salt__['powerdns.new_session'](True)
+  log.debug('powerdns: got session')
+
+  have_rrsets = __salt__['powerdns.get_zone_rrsets'](zone, session)
+
+  want_rrsets = []
+  payload = []
+
+  for rrset in rrsets:
+    this_rrset = {
+      'name': __salt__['powerdns.canonicalize_recname'](zone, rrset['name']),
+      'type': rrset['type'],
+    }
+
+    if 'ttl' in rrset:
+      this_rrset['ttl'] = rrset['ttl']
+
+    this_rrset['records'] = [
+      {
+        'content': record,
+        'disabled': False,
+      }
+      for record in rrset['records']
+    ]
+
+    want_rrsets.append(this_rrset)
+
+  up_to_date_rrsets = []
+  only_ttl_rrsets = []
+  only_records_rrsets = []
+
+  log.debug('powerdns: rrset payload BEFORE mangling')
+  log.debug(want_rrsets)
+
+  # TODO: this needs a second iteration over have_rrsets to remove records which are no longer in Salt
+
+  for i, want_rrset in enumerate(want_rrsets):
+    log.debug(want_rrset)
+    for have_rrset in have_rrsets:
+      log.debug(have_rrset)
+      if want_rrset['name'] == have_rrset['name'] and have_rrset['type'] == want_rrset['type']:
+        ttl_ok = False
+        records_ok = []
+
+        if 'ttl' in want_rrset and want_rrset['ttl'] == have_rrset['ttl'] or not 'ttl' in want_rrset:
+          ttl_ok = True
+
+        for ir, want_record in enumerate(want_rrset['records']):
+          log.debug(f'powerdns: reading wanted record {want_record}')
+
+          for have_record in have_rrset['records']:
+            log.debug(f'powernds: comparing against {have_record}')
+
+            if have_record == want_record:
+              log.debug('powerdns: matches')
+              records_ok.append(ir)
+              break
+
+            elif have_record['content'] == want_record['content'] and have_record['disabled'] != want_record['disabled']:
+              log.debug('powerdns: status mismatch')
+
+              if not want_rrset['name'] in ret['changes']:
+                ret['changes'][want_rrset['name']] = [{}]
+
+              if not 'old' in ret['changes'][want_rrset['name']][i] and not 'new' in ret['changes'][want_rrset['name']][i]:
+                ret['changes'][want_rrset['name']][i]['old'] = {}
+                ret['changes'][want_rrset['name']][i]['new'] = {}
+                
+              ret['changes'][want_rrset['name']][i]['old'].update({have_record['content']: not have_record['disabled']})
+              ret['changes'][want_rrset['name']][i]['new'].update({want_record['content']: not want_record['disabled']})
+
+              break
+
+          else:
+            log.debug(f'powerdns: not found')
+
+            if not want_rrset['name'] in ret['changes']:
+              ret['changes'][want_rrset['name']] = [{}]
+
+            if not 'old' in ret['changes'][want_rrset['name']][i] and not 'new' in ret['changes'][want_rrset['name']][i]:
+              ret['changes'][want_rrset['name']][i]['old'] = {}
+              ret['changes'][want_rrset['name']][i]['new'] = {}
+
+            ret['changes'][want_rrset['name']][i]['old'].update({want_record['content']: None})
+            ret['changes'][want_rrset['name']][i]['new'].update({want_record['content']: not want_record['disabled']})
+
+        all_records_ok = len(records_ok) == len(want_rrset['records'])
+        if ttl_ok and all_records_ok:
+          up_to_date_rrsets.append(i)
+
+        elif not ttl_ok and all_records_ok:
+          only_ttl_rrsets.append(i)
+          if not want_rrset['name'] in ret['changes']:
+            ret['changes'][want_rrset['name']] = [{}]
+          ret['changes'][want_rrset['name']][i] = {
+            'old': {'ttl': have_rrset['ttl']},
+            'new': {'ttl': want_rrset['ttl']},
+          }
+
+        elif ttl_ok and not all_records_ok:
+          only_records_rrsets.append(i)
+
+          # update of individual records not possible / this might be ok to drop ; just always write all records in the set
+          #for ir in records_ok:
+          #  want_rrset['records'].pop(ir)
+
+        break
+
+    else:
+      ret['changes'][want_rrset['name']] = [
+        {
+          'old': {},
+          'new': {
+            'ttl': want_rrset['ttl'],
+            'records': {
+              record['content']: not record['disabled']
+              for record in want_rrset.get('records', [])
+            }
+          },
+        },
+      ]
+
+  for i in up_to_date_rrsets:
+    want_rrsets.pop(i-1)
+
+  # API throws "No change for RRset" if attempting to patch only the TTL without records, bug?
+  #for i in only_ttl_rrsets:
+  #  del want_rrsets[i]['records']
+
+  # API requires ttl for record updates, this might be ok to drop
+  #for i in only_records_rrsets:
+  #  if 'ttl' in want_rrsets[i]:
+  #    del want_rrsets[i]['ttl']
+
+  log.debug('powerdns: rrset changes')
+  log.debug(ret['changes'])
+  log.debug('powerdns: rrset payload AFTER mangling')
+  log.debug(want_rrsets)
+
+  if want_rrsets:
+    if __opts__['test']:
+      ret['result'] = None
+      ret['comment'] = 'Resource sets would be updated.'
+      return ret
+
+    ok, status, output = __salt__['powerdns.patch_rrsets'](zone, 'REPLACE', session, rrsets=want_rrsets)
+
+    if ok:
+      ret['result'] = True
+      ret['comment'] = f'Resource sets updated: {status} - {output}'
+
+    else:
+      ret['result'] = False
+      ret['comment'] = f'Resource set update failed: {status} - {output}'
+
+    return ret
+
+  ret['result'] = True
+  ret['comment'] = 'Resource sets are already up to date.'
+  return ret

--- a/_states/powerdns.py
+++ b/_states/powerdns.py
@@ -5,8 +5,11 @@ def __virtual__():
         return __virtualname__
     return False
 
+from copy import deepcopy
+from dictdiffer import diff as dictdiff
 import logging
 log = logging.getLogger(__name__)
+
 
 def zone_present(name, kind=None, rrsets=None, masters=None, dnssec=None, nsec3param=None, nsec3narrow=None, presigned=None, soa_edit=None, soa_edit_api=None, api_rectify=None, catalog=None, nameservers=None, master_tsig_key_ids=None, slave_tsig_key_ids=None):
 
@@ -22,7 +25,7 @@ def zone_present(name, kind=None, rrsets=None, masters=None, dnssec=None, nsec3p
   if 'kind' in want_data:
     want_data['kind'] = want_data['kind'].capitalize()
 
-  ret = {'name': zone, 'changes': {}, 'result': False, 'comment': ''}
+  ret = {'name': zone, 'changes': {'old': {}, 'new': {}}, 'result': False, 'comment': ''}
 
   session = __salt__['powerdns.new_session'](True)
   log.debug('powerdns: got session')
@@ -33,166 +36,131 @@ def zone_present(name, kind=None, rrsets=None, masters=None, dnssec=None, nsec3p
   log.debug(f'powerdns: want data => {want_data}')
 
   if exists:
-    if 'nameservers' in want_data:
-      del want_data['nameservers']
-
-    have_data = {
-      key: value
-      for key, value in __salt__['powerdns.get_zone'](zone, session).items()
-      if key in want_data
-    }
-
+    have_data = __salt__['powerdns.get_zone'](zone, session)
     log.debug(f'powerdns: have data => {have_data}')
+    payload = have_data.copy()
 
-    payload = {}
-    for key, want_value in want_data.items():
-      log.debug(f'powerdns: reading wanted key "{key}"')
-      have_value = have_data[key]
+    for have_key, have_value in have_data.items():
+      log.debug(f'powerdns: reading have key {have_key}')
 
-      if type(want_value) != type(have_value):
-        log.error('powerdns: comparison of values with different instance types is not supported')
-        return False
+      if have_key in want_data:
+        want_value = want_data[have_key]
+        log.debug(f'powerdns: key {have_key} is wanted with value {want_value}')
 
-      if isinstance(want_value, list):
-        if key == 'nameservers':
-          want_value.sort()
-          have_value.sort()
+        payload.update(
+          {
+            have_key: deepcopy(want_value)
+          }
+        )
 
-        if key == 'rrsets':
-          for i, rrset in enumerate(want_value):
-            want_value[i-1]['name'] = __salt__['powerdns.canonicalize_recname'](zone, rrset['name'])
+        if isinstance(have_value, str) or isinstance(have_value, int):
+          if have_value == want_value:
+            log.debug(f'powerdns: str/int {have_value} already matches')
 
-          payload.update(
-            {
-              key: [
-                {
-                  'changetype': 'REPLACE',
-                  **rrset
-                } for rrset in want_value
-              ],
-            }
-          )
+          else:
+            ret['changes']['old'][have_key] = have_value
+            ret['changes']['new'][have_key] = want_value
 
-          if not 'rrsets' in ret['changes']:
-            ret['changes']['rrsets'] = {}
+        elif isinstance(have_value, list):  # rrset/nameserver list?
+          if have_key == 'nameserver':
+            have_value = have_value.sort()
+            want_value = want_value.sort()
 
-          for want_rrset in want_value:  # for dict in list of rrsets
-            log.debug(f'powerdns: want rrset {want_rrset}')
-            rrset_name = f'{want_rrset["name"]}_{want_rrset["type"]}'
+            if have_value == want_value:
+              log.debug(f'powerdns: list {have_value} already matches')
 
+            else:
+              # maybe make a diff of the lists here
+              ret['changes']['old'][have_key] = have_value
+              ret['changes']['new'][have_key] = want_value
+
+          elif have_key == 'rrsets':
+            processed_rrsets = []
+            processed_wanted_rrsets = []
+
+            # 1. preprocess rrsets
+            for i_rrs, rrset in enumerate(want_value):
+              rrset_name = __salt__['powerdns.canonicalize_recname'](zone, rrset['name'])
+              for i_rec, record in enumerate(rrset.get('records', [])):
+                if 'disabled' not in record:
+                  payload[have_key][i_rrs]['records'][i_rec]['disabled'] = False
+              if '.' not in rrset['name']:
+                payload[have_key][i_rrs]['name'] = rrset_name
+              if not rrset.get('comments', []):
+                payload[have_key][i_rrs]['comments'] = []
+
+            # 2. process changes to existing rrsets
             for have_rrset in have_value:
-              log.debug(f'powerdns: have rrset {have_rrset}')
+              processed_rrsets.append((have_rrset['name'], have_rrset['type']))
 
-              if want_rrset['name'] == have_rrset['name'] and want_rrset['type'] == have_rrset['type']:
-                log.debug('powerdns: match!')
+              for i, want_rrset in enumerate(payload[have_key]):
+                if have_rrset['name'] == want_rrset['name'] and have_rrset['type'] == want_rrset['type']:
+                  log.debug(f'powerdns: want_rrset {want_rrset}')
+                  log.debug('comparing')
+                  log.debug(have_rrset)
+                  log.debug(want_rrset)
+                  diff = list(dictdiff(have_rrset, want_rrset))
+                  log.debug(f'powerdns: have diff')
+                  for x in diff:
+                    log.debug(x)
 
-                for rrset_key in want_rrset.keys():
-                  log.debug(f'powerdns: parsing key "{rrset_key}"')
+                  if diff:
+                    if not 'rrset_diffs' in ret['changes']:
+                      ret['changes']['rrset_diffs'] = {}
 
-                  if rrset_key == 'name':
-                    continue
+                    if not name in ret['changes']['rrset_diffs']:
+                      ret['changes']['rrset_diffs'][name] = []
 
-                  if rrset_key in have_rrset:
-                    log.debug('powerdns: found wanted key in existing keys')
-
-                    if isinstance(want_rrset[rrset_key], str) or isinstance(want_rrset[rrset_key], int):
-                      if want_rrset[rrset_key] != have_rrset[rrset_key]:
-                        if rrset_name not in ret['changes']['rrsets']:
-                          ret['changes']['rrsets'][rrset_name] = {
-                            'old': {},
-                            'new': {},
-                          }
-
-                        ret['changes']['rrsets'][rrset_name]['old'] = have_rrset[rrset_key]
-                        ret['changes']['rrsets'][rrset_name]['new'] = want_rrset[rrset_key]
-
-                    elif isinstance(want_rrset[rrset_key], list):
-                      if rrset_key == 'comments':
-                        log.error('powerdns: comments in rrsets are not supported by the formula')
-
-                      have_rrset_records = sorted(have_rrset[rrset_key], key=lambda record: record['content'])
-                      want_rrset_records = sorted(want_rrset[rrset_key], key=lambda record: record['content'])
-
-                      if have_rrset_records == want_rrset_records:
-                        log.debug('powerdns: records match exactly')
-                        continue
-
-                      new_rrset_records = [record for record in want_rrset_records if record['content'] not in [record['content'] for record in have_rrset_records]]
-
-                      for i, want_rrset_record in enumerate(want_rrset_records):
-                        i = i-1
-                        want_rrset_record_disabled = want_rrset_record.get('disabled', False)
-                        if want_rrset_record['content'] == have_rrset_records[i]['content']:
-                          if want_rrset_record_disabled != have_rrset_records[i]['disabled']:
-                            if rrset_name not in ret['changes']['rrsets']:
-                              ret['changes']['rrsets'][rrset_name] = {
-                                'old': {},
-                                'new': {},
-                              }
-
-                            for x in ['old', 'new']:
-                              if 'records' not in ret['changes']['rrsets'][rrset_name][x]:
-                                ret['changes']['rrsets'][rrset_name][x]['records'] = []
-
-                            ret['changes']['rrsets'][rrset_name]['old']['records'].append({have_rrset_records[i]['name']: not have_rrset_records[i]['disabled']})
-                            ret['changes']['rrsets'][rrset_name]['new']['records'].append({want_rrset_record['name']: want_rrset_record_disabled})
-
-                      if new_rrset_records:
-                        log.debug(f'powerdns: new rrset records: {new_rrset_records}')
-
-                        for new_rrset_record in new_rrset_records:
-                          if rrset_name not in ret['changes']['rrsets']:
-                            ret['changes']['rrsets'][rrset_name] = {
-                              'old': {},
-                              'new': {},
-                            }
-
-                          for x in ['old', 'new']:
-                            if 'records' not in ret['changes']['rrsets'][rrset_name][x]:
-                              ret['changes']['rrsets'][rrset_name][x]['records'] = []
-
-                          ret['changes']['rrsets'][rrset_name]['old']['records'].append({new_rrset_record['content']: None})
-                          ret['changes']['rrsets'][rrset_name]['new']['records'].append({new_rrset_record['content']: not new_rrset_record.get('disabled', False)})
+                    ret['changes']['rrset_diffs'][name].append(diff)
 
                   else:
-                    if rrset_name not in ret['changes']['rrsets']:
-                      ret['changes']['rrsets'][rrset_name] = {
-                        'old': {},
-                        'new': {},
-                      }
+                    payload[have_key].pop(i)
 
-                    ret['changes']['rrsets'][rrset_name]['old'][rrset_key] = None
-                    ret['changes']['rrsets'][rrset_name]['new'][rrset_key] = want_rrset[rrset_key]                    
+                  wrrsettup = (want_rrset['name'], want_rrset['type'])
+                  processed_rrsets.remove(wrrsettup)
+                  processed_wanted_rrsets.append(wrrsettup)
 
-                log.debug('powerdns: breaking after analyzing match')
-                break
+                  break
 
-            # no existing rrset found with the given name
-            else:
-              log.debug(f'powerdns: rrset "{rrset_name}" not found')
-              ret['changes']['rrsets'][rrset_name] = {
-                'old': {},
-                'new': want_rrset,
-              }
+            # 3. process new rrsets
+            for want_rrset in payload[have_key]:
+              for wrrsettup in processed_wanted_rrsets:
+                if want_rrset['name'] == wrrsettup[0] and want_rrset['type'] == wrrsettup[1]:
+                  break
 
-          if not ret['changes']['rrsets']:
-            del ret['changes']['rrsets']
+              else:
+                if not 'rrset_additions' in ret['changes']:
+                  ret['changes']['rrset_additions'] = []
 
-      if isinstance(want_value, str) or isinstance(want_value, list) and key != 'rrsets':
-        if want_value != have_value:
-          log.debug('powerdns: value differs')
-          ret['changes'][key] = {
-            'old': have_value,
-            'new': want_value,
-          }
+                ret['changes']['rrset_additions'].append(rrset)
 
-          payload.update(
-            {
-              key: want_value,
-            }
-          )
+            # 4. process rrset removals
+            for rrset in processed_rrsets:
+              if rrset[1] == 'SOA':
+                continue
+
+              payload[have_key].append(
+                {
+                  'name': rrset[0],
+                  'type': rrset[1],
+                  'changetype': 'DELETE',
+                }
+              )
+
+              if not 'rrset_deletions' in ret['changes']:
+                ret['changes']['rrset_deletions'] = []
+
+              ret['changes']['rrset_deletions'].append(rrset)
+
+    if 'rrset_diffs' in ret['changes']:
+      for i, rrset in enumerate(payload['rrsets']):
+        payload['rrsets'][i]['changetype'] = 'REPLACE'
 
     log.debug(f'powerdns: payload: {payload}')
+
+    for x in ['old', 'new']:
+      if not ret['changes'][x]:
+        del ret['changes'][x]
 
     if not ret['changes']:
       ret['result'] = True
@@ -231,7 +199,6 @@ def zone_present(name, kind=None, rrsets=None, masters=None, dnssec=None, nsec3p
       ret['comment'] = 'Zone would be created.'
       return ret
 
-    payload = want_data
     ok, status, output = __salt__['powerdns.post_zone'](zone, payload, session)
 
     if ok:
@@ -243,168 +210,3 @@ def zone_present(name, kind=None, rrsets=None, masters=None, dnssec=None, nsec3p
       ret['comment'] = f'Zone creation failed: {status} - {output}'
 
     return ret
-
-def rrsets_present(name, rrsets):
-  zone = __salt__['powerdns.canonicalize_name'](name)
-  ret = {'name': zone, 'changes': {}, 'result': False, 'comment': ''}
-
-  session = __salt__['powerdns.new_session'](True)
-  log.debug('powerdns: got session')
-
-  have_rrsets = __salt__['powerdns.get_zone_rrsets'](zone, session)
-
-  want_rrsets = []
-  payload = []
-
-  for rrset in rrsets:
-    this_rrset = {
-      'name': __salt__['powerdns.canonicalize_recname'](zone, rrset['name']),
-      'type': rrset['type'],
-    }
-
-    if 'ttl' in rrset:
-      this_rrset['ttl'] = rrset['ttl']
-
-    this_rrset['records'] = [
-      {
-        'content': record,
-        'disabled': False,
-      }
-      for record in rrset['records']
-    ]
-
-    want_rrsets.append(this_rrset)
-
-  up_to_date_rrsets = []
-  only_ttl_rrsets = []
-  only_records_rrsets = []
-
-  log.debug('powerdns: rrset payload BEFORE mangling')
-  log.debug(want_rrsets)
-
-  # TODO: this needs a second iteration over have_rrsets to remove records which are no longer in Salt
-
-  for i, want_rrset in enumerate(want_rrsets):
-    log.debug(want_rrset)
-    for have_rrset in have_rrsets:
-      log.debug(have_rrset)
-      if want_rrset['name'] == have_rrset['name'] and have_rrset['type'] == want_rrset['type']:
-        ttl_ok = False
-        records_ok = []
-
-        if 'ttl' in want_rrset and want_rrset['ttl'] == have_rrset['ttl'] or not 'ttl' in want_rrset:
-          ttl_ok = True
-
-        for ir, want_record in enumerate(want_rrset['records']):
-          log.debug(f'powerdns: reading wanted record {want_record}')
-
-          for have_record in have_rrset['records']:
-            log.debug(f'powernds: comparing against {have_record}')
-
-            if have_record == want_record:
-              log.debug('powerdns: matches')
-              records_ok.append(ir)
-              break
-
-            elif have_record['content'] == want_record['content'] and have_record['disabled'] != want_record['disabled']:
-              log.debug('powerdns: status mismatch')
-
-              if not want_rrset['name'] in ret['changes']:
-                ret['changes'][want_rrset['name']] = [{}]
-
-              if not 'old' in ret['changes'][want_rrset['name']][i] and not 'new' in ret['changes'][want_rrset['name']][i]:
-                ret['changes'][want_rrset['name']][i]['old'] = {}
-                ret['changes'][want_rrset['name']][i]['new'] = {}
-                
-              ret['changes'][want_rrset['name']][i]['old'].update({have_record['content']: not have_record['disabled']})
-              ret['changes'][want_rrset['name']][i]['new'].update({want_record['content']: not want_record['disabled']})
-
-              break
-
-          else:
-            log.debug(f'powerdns: not found')
-
-            if not want_rrset['name'] in ret['changes']:
-              ret['changes'][want_rrset['name']] = [{}]
-
-            if not 'old' in ret['changes'][want_rrset['name']][i] and not 'new' in ret['changes'][want_rrset['name']][i]:
-              ret['changes'][want_rrset['name']][i]['old'] = {}
-              ret['changes'][want_rrset['name']][i]['new'] = {}
-
-            ret['changes'][want_rrset['name']][i]['old'].update({want_record['content']: None})
-            ret['changes'][want_rrset['name']][i]['new'].update({want_record['content']: not want_record['disabled']})
-
-        all_records_ok = len(records_ok) == len(want_rrset['records'])
-        if ttl_ok and all_records_ok:
-          up_to_date_rrsets.append(i)
-
-        elif not ttl_ok and all_records_ok:
-          only_ttl_rrsets.append(i)
-          if not want_rrset['name'] in ret['changes']:
-            ret['changes'][want_rrset['name']] = [{}]
-          ret['changes'][want_rrset['name']][i] = {
-            'old': {'ttl': have_rrset['ttl']},
-            'new': {'ttl': want_rrset['ttl']},
-          }
-
-        elif ttl_ok and not all_records_ok:
-          only_records_rrsets.append(i)
-
-          # update of individual records not possible / this might be ok to drop ; just always write all records in the set
-          #for ir in records_ok:
-          #  want_rrset['records'].pop(ir)
-
-        break
-
-    else:
-      ret['changes'][want_rrset['name']] = [
-        {
-          'old': {},
-          'new': {
-            'ttl': want_rrset['ttl'],
-            'records': {
-              record['content']: not record['disabled']
-              for record in want_rrset.get('records', [])
-            }
-          },
-        },
-      ]
-
-  for i in up_to_date_rrsets:
-    want_rrsets.pop(i-1)
-
-  # API throws "No change for RRset" if attempting to patch only the TTL without records, bug?
-  #for i in only_ttl_rrsets:
-  #  del want_rrsets[i]['records']
-
-  # API requires ttl for record updates, this might be ok to drop
-  #for i in only_records_rrsets:
-  #  if 'ttl' in want_rrsets[i]:
-  #    del want_rrsets[i]['ttl']
-
-  log.debug('powerdns: rrset changes')
-  log.debug(ret['changes'])
-  log.debug('powerdns: rrset payload AFTER mangling')
-  log.debug(want_rrsets)
-
-  if want_rrsets:
-    if __opts__['test']:
-      ret['result'] = None
-      ret['comment'] = 'Resource sets would be updated.'
-      return ret
-
-    ok, status, output = __salt__['powerdns.patch_rrsets'](zone, 'REPLACE', session, rrsets=want_rrsets)
-
-    if ok:
-      ret['result'] = True
-      ret['comment'] = f'Resource sets updated: {status} - {output}'
-
-    else:
-      ret['result'] = False
-      ret['comment'] = f'Resource set update failed: {status} - {output}'
-
-    return ret
-
-  ret['result'] = True
-  ret['comment'] = 'Resource sets are already up to date.'
-  return ret


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [x] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

Yes.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

1. Replace proprietary and unmaintained library with native HTTP calls
2. Support full zone metadata and rrset updates (additions, modifications, removals) with proper test=True/test=False handling and detailed diffs about changes utilizing the same data structure as the PowerDNS API itself

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

Pillar abstraction is not yet implemented. Hence a sample state file instead:

```
my_zone:
  powerdns.zone_present:
    - name: test2.pdns.home.lysergic.dev
    - kind: native
    - rrsets:
        - name: host5
          type: A
          ttl: 300
          records:
            - content: 127.0.0.3
            - content: 127.0.0.5
              disabled: True
        - name: host5
          type: AAAA
          ttl: 300
          records:
            - content: fe80::1
            - content: fe80::2
        - name: host6
          type: A
          ttl: 300
          records:
            - content: 127.0.0.3
```

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

Exceeds GitHub maximum body size.

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->

This is a work in progress effort. I am sharing it already to gather potential early feedback and to learn whether such a big change is of interest to this project at all. The code still needs lots of cleanup, and it is of course lacking documentation and tests (for effective testing, the test suite will need to spin up a PowerDNS, which I am not yet sure how to integrate into the `kitchen` suite in this repository).

Most of the logic is around getting a usable diff for the changes to make for an experience as with other Salt states. Unfortunately, the PowerDNS API itself does not yet natively support operating in a dry-run mode with diff output.

The existing functions are for the most part refactored. Having a single `zone_present()` state function instead of separate rrset logic allows following of the upstream PowerDNS API data structure, making the state both easier to use for users (the same documentation as the upstream API can be followed) and easier to adapt in case of future changes to the upstream API.